### PR TITLE
[Test] [Coupon] 할인 쿠폰 테스트 코드 구현

### DIFF
--- a/src/main/java/com/example/springplusteamproject/domain/coupon/repository/DiscountCouponRepository.java
+++ b/src/main/java/com/example/springplusteamproject/domain/coupon/repository/DiscountCouponRepository.java
@@ -14,5 +14,5 @@ public interface DiscountCouponRepository extends JpaRepository<DiscountCoupon, 
                                                  @Param("storeId") Long storeId);
 
     @Query("SELECT dc FROM DiscountCoupon dc WHERE dc.id = :couponId AND dc.store.id = :storeId")
-    Optional<DiscountCoupon> findAvailableCoupon(@Param("storeId") Long storeId, @Param("couponId") Long couponId);
+    Optional<DiscountCoupon> findIssuableCoupon(@Param("storeId") Long storeId, @Param("couponId") Long couponId);
 }

--- a/src/main/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceImpl.java
+++ b/src/main/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceImpl.java
@@ -31,7 +31,6 @@ public class DiscountCouponServiceImpl implements DiscountCouponService {
         User user = userRepository.findByEmail(principal.getUsername())
             .orElseThrow(() -> new ApiException(ErrorStatus.USER_NOT_FOUND));
         user.validateDelete();
-        user.validateOwner();
 
         Store store = storeRepository.findByIdAndDeletedFalse(storeId)
             .orElseThrow(() -> new ApiException(ErrorStatus.STORE_NOT_FOUND));

--- a/src/main/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceImpl.java
+++ b/src/main/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceImpl.java
@@ -33,13 +33,11 @@ public class DiscountCouponServiceImpl implements DiscountCouponService {
         user.validateDelete();
         user.validateOwner();
 
-        // TODO store의 예외 코드 추가되면 해당 예외 코드로 수정
         Store store = storeRepository.findByIdAndDeletedFalse(storeId)
-            .orElseThrow(() -> new ApiException(ErrorStatus.FORBIDDEN));
-        // TODO store의 인가 처리 끝나면 추가
-//        if (!Objects.equals(user.getId(), store.getUser().getId())) {
-//            throw new ApiException(ErrorStatus.ROLE_ADMIN_FORBIDDEN);
-//        }
+            .orElseThrow(() -> new ApiException(ErrorStatus.STORE_NOT_FOUND));
+        if (!Objects.equals(user.getId(), store.getUser().getId())) {
+            throw new ApiException(ErrorStatus.ROLE_OWNER_FORBIDDEN);
+        }
 
         DiscountCoupon discountCoupon = createDiscountCoupon(store, requestDto);
         DiscountCoupon savedDiscountCoupon = discountCouponRepository.save(discountCoupon);

--- a/src/main/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceImpl.java
@@ -37,9 +37,9 @@ public class UserCouponServiceImpl implements UserCouponService {
         validateActivateStore(storeId);
 
         List<Long> couponIds = userCouponRepository.findHavingCouponIds(user.getId(), storeId);
-        List<DiscountCoupon> availableCouponList = discountCouponRepository.findIssuableCouponList(couponIds, storeId);
+        List<DiscountCoupon> issuableCouponList = discountCouponRepository.findIssuableCouponList(couponIds, storeId);
 
-        return availableCouponList.stream().map(IssuableUserCouponResponseDto::from).collect(Collectors.toList());
+        return issuableCouponList.stream().map(IssuableUserCouponResponseDto::from).collect(Collectors.toList());
     }
 
     @Override
@@ -51,9 +51,9 @@ public class UserCouponServiceImpl implements UserCouponService {
         validateCouponNotIssued(user.getId(), couponId);
 
         validateActivateStore(storeId);
-        DiscountCoupon availableCoupon = validateAvailableCoupon(storeId, couponId);
+        DiscountCoupon issuableCoupon = validateIssuableCoupon(storeId, couponId);
 
-        return IssuableUserCouponResponseDto.from(availableCoupon);
+        return IssuableUserCouponResponseDto.from(issuableCoupon);
     }
 
     @Override
@@ -64,13 +64,13 @@ public class UserCouponServiceImpl implements UserCouponService {
         validateCouponNotIssued(user.getId(), couponId);
 
         validateActivateStore(storeId);
-        DiscountCoupon availableCoupon = validateAvailableCoupon(storeId, couponId);
+        DiscountCoupon issuableCoupon = validateIssuableCoupon(storeId, couponId);
 
-        UserCoupon issueCoupon = createUserCoupon(user, availableCoupon);
+        UserCoupon issueCoupon = createUserCoupon(user, issuableCoupon);
         UserCoupon savedCoupon = userCouponRepository.save(issueCoupon);
-        availableCoupon.decreaseStock();
+        issuableCoupon.decreaseStock();
 
-        return UserCouponIssueResponseDto.from(availableCoupon, savedCoupon);
+        return UserCouponIssueResponseDto.from(issuableCoupon, savedCoupon);
     }
 
     @Override
@@ -95,12 +95,12 @@ public class UserCouponServiceImpl implements UserCouponService {
         return user;
     }
 
-    private DiscountCoupon validateAvailableCoupon(Long storeId, Long couponId) {
+    private DiscountCoupon validateIssuableCoupon(Long storeId, Long couponId) {
 
-        DiscountCoupon availableCoupon = discountCouponRepository.findAvailableCoupon(storeId, couponId)
+        DiscountCoupon issuableCoupon = discountCouponRepository.findIssuableCoupon(storeId, couponId)
             .orElseThrow(() -> new ApiException(ErrorStatus.COUPON_NOT_FOUND));
 
-        return availableCoupon;
+        return issuableCoupon;
     }
 
     private void validateActivateStore(Long storeId) {

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceTest.java
@@ -1,0 +1,88 @@
+package com.example.springplusteamproject.domain.coupon.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.springplusteamproject.common.exception.ApiException;
+import com.example.springplusteamproject.domain.coupon.dto.request.DiscountCouponRequestDto;
+import com.example.springplusteamproject.domain.coupon.entity.DiscountCoupon;
+import com.example.springplusteamproject.domain.coupon.repository.DiscountCouponRepository;
+import com.example.springplusteamproject.domain.store.entity.Store;
+import com.example.springplusteamproject.domain.store.repository.StoreRepository;
+import com.example.springplusteamproject.domain.user.entity.User;
+import com.example.springplusteamproject.domain.user.repository.UserRepository;
+import com.example.springplusteamproject.security.CustomUserPrincipal;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DiscountCouponServiceTest {
+
+    @Mock
+    private DiscountCouponRepository discountCouponRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private DiscountCouponServiceImpl discountCouponService;
+
+    private DiscountCouponRequestDto requestDto = new DiscountCouponRequestDto("5000원 할인", 5000L, LocalDate.now(), LocalDate.now(), 100L);
+
+    private DiscountCoupon discountCoupon;
+
+    @BeforeEach
+    void setUp() {
+        discountCoupon = DiscountCoupon.builder()
+            .id(1L)
+            .build();
+    }
+
+    @Test
+    void 쿠폰_등록에_성공한다() {
+        Long storeId = 1L;
+
+        CustomUserPrincipal principal = mock(CustomUserPrincipal.class);
+        User user = mock(User.class);
+        Store store = mock(Store.class);
+
+        when(userRepository.findByEmail(principal.getUsername())).thenReturn(Optional.of(user));
+        when(storeRepository.findByIdAndDeletedFalse(storeId)).thenReturn(Optional.of(store));
+        when(discountCouponRepository.save(any(DiscountCoupon.class))).thenReturn(discountCoupon);
+
+        discountCouponService.createCoupon(storeId, requestDto, principal);
+
+        verify(userRepository).findByEmail(principal.getUsername());
+        verify(storeRepository).findByIdAndDeletedFalse(storeId);
+        verify(discountCouponRepository).save(any(DiscountCoupon.class));
+    }
+
+    @Test
+    void 존재하지_않는_가게일_경우_예외가_발생한다() {
+        Long storeId = 1L;
+        String email = "1@gmail.com";
+        CustomUserPrincipal principal = mock(CustomUserPrincipal.class);
+
+        when(principal.getUsername()).thenReturn(email);
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(mock(User.class)));
+        when(storeRepository.findByIdAndDeletedFalse(storeId)).thenReturn(Optional.empty());
+
+        assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
+
+        verify(userRepository).findByEmail(email); verify(storeRepository).findByIdAndDeletedFalse(storeId);
+    }
+
+    // TODO 사용자 인가 부분 수정 후 인가 관련 실패 테스트 코드 추가
+}

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceTest.java
@@ -2,9 +2,10 @@ package com.example.springplusteamproject.domain.coupon.service;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.example.springplusteamproject.common.exception.ApiException;
 import com.example.springplusteamproject.domain.coupon.dto.request.DiscountCouponRequestDto;
@@ -40,27 +41,32 @@ public class DiscountCouponServiceTest {
     private DiscountCouponServiceImpl discountCouponService;
 
     private DiscountCouponRequestDto requestDto = new DiscountCouponRequestDto("5000원 할인", 5000L, LocalDate.now(), LocalDate.now(), 100L);
-
     private DiscountCoupon discountCoupon;
+    private CustomUserPrincipal principal;
+    private Long storeId;
+    private String email;
+    private Store store;
+    private User user;
 
     @BeforeEach
     void setUp() {
         discountCoupon = DiscountCoupon.builder()
             .id(1L)
             .build();
+        storeId = 1L;
+        principal = mock(CustomUserPrincipal.class);
+        user = mock(User.class);
+        store = mock(Store.class);
+        email = "test@gmail.com";
     }
 
     @Test
     void 쿠폰_등록에_성공한다() {
-        Long storeId = 1L;
 
-        CustomUserPrincipal principal = mock(CustomUserPrincipal.class);
-        User user = mock(User.class);
-        Store store = mock(Store.class);
-
-        when(userRepository.findByEmail(principal.getUsername())).thenReturn(Optional.of(user));
-        when(storeRepository.findByIdAndDeletedFalse(storeId)).thenReturn(Optional.of(store));
-        when(discountCouponRepository.save(any(DiscountCoupon.class))).thenReturn(discountCoupon);
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
+        given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
+        given(store.getUser()).willReturn(user);
+        given(discountCouponRepository.save(any(DiscountCoupon.class))).willReturn(discountCoupon);
 
         discountCouponService.createCoupon(storeId, requestDto, principal);
 
@@ -71,18 +77,34 @@ public class DiscountCouponServiceTest {
 
     @Test
     void 존재하지_않는_가게일_경우_예외가_발생한다() {
-        Long storeId = 1L;
-        String email = "1@gmail.com";
-        CustomUserPrincipal principal = mock(CustomUserPrincipal.class);
 
-        when(principal.getUsername()).thenReturn(email);
-        when(userRepository.findByEmail(email)).thenReturn(Optional.of(mock(User.class)));
-        when(storeRepository.findByIdAndDeletedFalse(storeId)).thenReturn(Optional.empty());
+        given(principal.getUsername()).willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(mock(User.class)));
+        given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.empty());
 
         assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
 
-        verify(userRepository).findByEmail(email); verify(storeRepository).findByIdAndDeletedFalse(storeId);
+        verify(userRepository).findByEmail(email);
+        verify(storeRepository).findByIdAndDeletedFalse(storeId);
+        verify(discountCouponRepository, never()).save(discountCoupon);
     }
 
-    // TODO 사용자 인가 부분 수정 후 인가 관련 실패 테스트 코드 추가
+    @Test
+    void 가게_소유주가_아닌_사용자는_쿠폰_등록이_불가능하다() {
+
+        User anotherUser = mock(User.class);
+
+        given(principal.getUsername()).willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
+        given(user.getId()).willReturn(1L);
+        given(anotherUser.getId()).willReturn(2L);
+        given(store.getUser()).willReturn(anotherUser);
+
+        assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
+
+        verify(userRepository).findByEmail(email);
+        verify(storeRepository).findByIdAndDeletedFalse(storeId);
+        verify(discountCouponRepository, never()).save(discountCoupon);
+    }
 }

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.springplusteamproject.domain.coupon.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.example.springplusteamproject.common.exception.ApiException;
+import com.example.springplusteamproject.common.status.ErrorStatus;
 import com.example.springplusteamproject.domain.coupon.dto.request.DiscountCouponRequestDto;
 import com.example.springplusteamproject.domain.coupon.entity.DiscountCoupon;
 import com.example.springplusteamproject.domain.coupon.repository.DiscountCouponRepository;
@@ -82,11 +84,13 @@ public class DiscountCouponServiceTest {
         given(userRepository.findByEmail(email)).willReturn(Optional.of(mock(User.class)));
         given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.empty());
 
-        assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
+        ApiException exception = assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
 
         verify(userRepository).findByEmail(email);
         verify(storeRepository).findByIdAndDeletedFalse(storeId);
         verify(discountCouponRepository, never()).save(discountCoupon);
+
+        assertEquals(ErrorStatus.STORE_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test
@@ -101,10 +105,12 @@ public class DiscountCouponServiceTest {
         given(anotherUser.getId()).willReturn(2L);
         given(store.getUser()).willReturn(anotherUser);
 
-        assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
+        ApiException exception = assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
 
         verify(userRepository).findByEmail(email);
         verify(storeRepository).findByIdAndDeletedFalse(storeId);
         verify(discountCouponRepository, never()).save(discountCoupon);
+
+        assertEquals(ErrorStatus.ROLE_OWNER_FORBIDDEN, exception.getErrorCode());
     }
 }

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/DiscountCouponServiceTest.java
@@ -1,21 +1,22 @@
 package com.example.springplusteamproject.domain.coupon.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.example.springplusteamproject.common.exception.ApiException;
 import com.example.springplusteamproject.common.status.ErrorStatus;
 import com.example.springplusteamproject.domain.coupon.dto.request.DiscountCouponRequestDto;
+import com.example.springplusteamproject.domain.coupon.dto.response.DiscountCouponResponseDto;
 import com.example.springplusteamproject.domain.coupon.entity.DiscountCoupon;
 import com.example.springplusteamproject.domain.coupon.repository.DiscountCouponRepository;
 import com.example.springplusteamproject.domain.store.entity.Store;
 import com.example.springplusteamproject.domain.store.repository.StoreRepository;
 import com.example.springplusteamproject.domain.user.entity.User;
+import com.example.springplusteamproject.domain.user.entity.UserRole;
 import com.example.springplusteamproject.domain.user.repository.UserRepository;
 import com.example.springplusteamproject.security.CustomUserPrincipal;
 import java.time.LocalDate;
@@ -46,7 +47,6 @@ public class DiscountCouponServiceTest {
     private DiscountCoupon discountCoupon;
     private CustomUserPrincipal principal;
     private Long storeId;
-    private String email;
     private Store store;
     private User user;
 
@@ -54,12 +54,23 @@ public class DiscountCouponServiceTest {
     void setUp() {
         discountCoupon = DiscountCoupon.builder()
             .id(1L)
+            .couponName("5000원 할인")
+            .discount(5000L)
+            .stock(500L)
             .build();
         storeId = 1L;
-        principal = mock(CustomUserPrincipal.class);
-        user = mock(User.class);
-        store = mock(Store.class);
-        email = "test@gmail.com";
+        user = User.builder()
+            .id(1L)
+            .nickname("가게 주인")
+            .email("1@gmail.com")
+            .userRole(UserRole.OWNER)
+            .build();
+        store = Store.builder()
+            .id(1L)
+            .name("가게 이름")
+            .user(user)
+            .build();
+        principal = new CustomUserPrincipal(user);
     }
 
     @Test
@@ -67,50 +78,48 @@ public class DiscountCouponServiceTest {
 
         given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
         given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
-        given(store.getUser()).willReturn(user);
         given(discountCouponRepository.save(any(DiscountCoupon.class))).willReturn(discountCoupon);
 
-        discountCouponService.createCoupon(storeId, requestDto, principal);
+        DiscountCouponResponseDto responseDto = discountCouponService.createCoupon(storeId, requestDto, principal);
 
-        verify(userRepository).findByEmail(principal.getUsername());
-        verify(storeRepository).findByIdAndDeletedFalse(storeId);
-        verify(discountCouponRepository).save(any(DiscountCoupon.class));
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.getId()).isEqualTo(discountCoupon.getId());
+        assertThat(responseDto.getCouponName()).isEqualTo(discountCoupon.getCouponName());
+        assertThat(responseDto.getDiscount()).isEqualTo(discountCoupon.getDiscount());
     }
 
     @Test
     void 존재하지_않는_가게일_경우_예외가_발생한다() {
 
-        given(principal.getUsername()).willReturn(email);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(mock(User.class)));
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
         given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.empty());
 
         ApiException exception = assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
 
-        verify(userRepository).findByEmail(email);
-        verify(storeRepository).findByIdAndDeletedFalse(storeId);
         verify(discountCouponRepository, never()).save(discountCoupon);
 
-        assertEquals(ErrorStatus.STORE_NOT_FOUND, exception.getErrorCode());
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.STORE_NOT_FOUND);
     }
 
     @Test
     void 가게_소유주가_아닌_사용자는_쿠폰_등록이_불가능하다() {
 
-        User anotherUser = mock(User.class);
+        User anotherUser = User.builder()
+            .id(2L)
+            .nickname("다른 가게 주인")
+            .email("2@gmail.com")
+            .userRole(UserRole.OWNER)
+            .build();
 
-        given(principal.getUsername()).willReturn(email);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        principal = new CustomUserPrincipal(anotherUser);
+
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(anotherUser));
         given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
-        given(user.getId()).willReturn(1L);
-        given(anotherUser.getId()).willReturn(2L);
-        given(store.getUser()).willReturn(anotherUser);
 
         ApiException exception = assertThrows(ApiException.class, () -> discountCouponService.createCoupon(storeId, requestDto, principal));
 
-        verify(userRepository).findByEmail(email);
-        verify(storeRepository).findByIdAndDeletedFalse(storeId);
         verify(discountCouponRepository, never()).save(discountCoupon);
 
-        assertEquals(ErrorStatus.ROLE_OWNER_FORBIDDEN, exception.getErrorCode());
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.ROLE_OWNER_FORBIDDEN);
     }
 }

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceTest.java
@@ -1,16 +1,14 @@
 package com.example.springplusteamproject.domain.coupon.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.example.springplusteamproject.common.exception.ApiException;
 import com.example.springplusteamproject.common.status.ErrorStatus;
-import com.example.springplusteamproject.domain.coupon.dto.request.DiscountCouponRequestDto;
 import com.example.springplusteamproject.domain.coupon.dto.response.IssuableUserCouponResponseDto;
 import com.example.springplusteamproject.domain.coupon.dto.response.UserCouponIssueResponseDto;
 import com.example.springplusteamproject.domain.coupon.entity.DiscountCoupon;
@@ -20,9 +18,9 @@ import com.example.springplusteamproject.domain.coupon.repository.UserCouponRepo
 import com.example.springplusteamproject.domain.store.entity.Store;
 import com.example.springplusteamproject.domain.store.repository.StoreRepository;
 import com.example.springplusteamproject.domain.user.entity.User;
+import com.example.springplusteamproject.domain.user.entity.UserRole;
 import com.example.springplusteamproject.domain.user.repository.UserRepository;
 import com.example.springplusteamproject.security.CustomUserPrincipal;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,57 +48,62 @@ class UserCouponServiceTest {
     @InjectMocks
     private UserCouponServiceImpl userCouponService;
 
-    private DiscountCouponRequestDto requestDto = new DiscountCouponRequestDto("5000원 할인", 5000L, LocalDate.now(),
-            LocalDate.now(), 100L);
     private DiscountCoupon issuedDiscountCoupon;
     private DiscountCoupon discountCoupon;
     private CustomUserPrincipal principal;
     private UserCoupon userCoupon;
     private Long storeId;
-    private String email;
     private Store store;
     private User user;
 
     @BeforeEach
     void setUp() {
         issuedDiscountCoupon = DiscountCoupon.builder()
-                .id(2L)
-                .build();
+            .id(2L)
+            .couponName("5000원 할인")
+            .discount(5000L)
+            .stock(500L)
+            .build();
         discountCoupon = DiscountCoupon.builder()
-                .id(1L)
-                .couponName("쿠폰이름")
-                .stock(10L)
-                .build();
+            .id(1L)
+            .couponName("5000원 할인")
+            .discount(5000L)
+            .stock(500L)
+            .build();
         userCoupon = UserCoupon.builder()
-                .id(1L)
-                .discountCoupon(discountCoupon)
-                .build();
-
+            .id(1L)
+            .discountCoupon(discountCoupon)
+            .build();
         storeId = 1L;
-        principal = mock(CustomUserPrincipal.class);
-        user = mock(User.class);
-        store = mock(Store.class);
-        email = "test@gmail.com";
+        user = User.builder()
+            .id(1L)
+            .nickname("가게 주인")
+            .email("1@gmail.com")
+            .userRole(UserRole.OWNER)
+            .build();
+        store = Store.builder()
+            .id(1L)
+            .name("가게 이름")
+            .user(user)
+            .build();
+        principal = new CustomUserPrincipal(user);
     }
 
     @Test
     void 발급_가능한_쿠폰_목록_조회에_성공한다() {
 
-        given(principal.getUsername()).willReturn(email);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
         given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
         given(userCouponRepository.findHavingCouponIds(user.getId(), storeId)).willReturn(List.of(2L));
         given(discountCouponRepository.findIssuableCouponList(List.of(2L), storeId)).willReturn(
-                List.of(discountCoupon));
+            List.of(discountCoupon));
 
         List<IssuableUserCouponResponseDto> responseDtos = userCouponService.findIssuableUserCoupons(storeId,
-                principal);
-        assertEquals(1, responseDtos.size());
+            principal);
 
-        verify(userRepository).findByEmail(email);
-        verify(storeRepository).findByIdAndDeletedFalse(storeId);
-        verify(userCouponRepository).findHavingCouponIds(user.getId(), storeId);
-        verify(discountCouponRepository).findIssuableCouponList(List.of(2L), storeId);
+        assertThat(responseDtos).hasSize(1);
+        assertThat(responseDtos.get(0).getCouponName()).isEqualTo(discountCoupon.getCouponName());
+        assertThat(responseDtos.get(0).getDiscount()).isEqualTo(discountCoupon.getDiscount());
     }
 
     @Test
@@ -108,38 +111,32 @@ class UserCouponServiceTest {
 
         Long couponId = 1L;
 
-        given(principal.getUsername()).willReturn(email);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
         given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(false);
         given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
         given(discountCouponRepository.findIssuableCoupon(storeId, couponId)).willReturn(Optional.of(discountCoupon));
 
         IssuableUserCouponResponseDto responseDto = userCouponService.findIssuableUserCoupon(storeId, couponId,
-                principal);
+            principal);
 
-        verify(userRepository).findByEmail(email);
-        verify(userCouponRepository).existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId);
-        verify(storeRepository).findByIdAndDeletedFalse(storeId);
-        verify(discountCouponRepository).findIssuableCoupon(storeId, couponId);
+        assertThat(responseDto.getCouponName()).isEqualTo(discountCoupon.getCouponName());
+        assertThat(responseDto.getDiscount()).isEqualTo(discountCoupon.getDiscount());
     }
 
     @Test
     void 이미_발급_받은_쿠폰은_상세_조회에_실패한다() {
 
-        Long couponId = 1L;
+        Long issuedCouponId = 2L;
 
-        given(principal.getUsername()).willReturn(email);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
-        given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(true);
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
+        given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), issuedCouponId)).willReturn(true);
 
-        ApiException exception = assertThrows(ApiException.class, () -> userCouponService.findIssuableUserCoupon(storeId, couponId, principal));
+        ApiException exception = assertThrows(ApiException.class,
+            () -> userCouponService.findIssuableUserCoupon(storeId, issuedCouponId, principal));
 
-        assertEquals(ErrorStatus.COUPON_ALREADY_ISSUED, exception.getErrorCode());
+        verify(discountCouponRepository, never()).findIssuableCoupon(storeId, issuedCouponId);
 
-        verify(userRepository).findByEmail(email);
-        verify(userCouponRepository).existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId);
-        verify(storeRepository, never()).findByIdAndDeletedFalse(storeId);
-        verify(discountCouponRepository, never()).findIssuableCoupon(storeId, couponId);
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.COUPON_ALREADY_ISSUED);
     }
 
     @Test
@@ -147,56 +144,47 @@ class UserCouponServiceTest {
 
         Long couponId = 1L;
 
-        given(principal.getUsername()).willReturn(email);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
         given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(false);
         given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
         given(discountCouponRepository.findIssuableCoupon(storeId, couponId)).willReturn(Optional.of(discountCoupon));
         given(userCouponRepository.save(any(UserCoupon.class))).willReturn(userCoupon);
 
-        userCouponService.issueUserCoupon(storeId, couponId, principal);
+        UserCouponIssueResponseDto responseDto = userCouponService.issueUserCoupon(storeId, couponId, principal);
 
-        verify(userRepository).findByEmail(email);
-        verify(userCouponRepository).existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId);
-        verify(storeRepository).findByIdAndDeletedFalse(storeId);
-        verify(discountCouponRepository).findIssuableCoupon(storeId, couponId);
-        verify(userCouponRepository).save(any(UserCoupon.class));
-
-        assertEquals(discountCoupon.getStock(), 9L);
+        assertThat(discountCoupon.getStock()).isEqualTo(499L);
+        assertThat(responseDto.getCouponName()).isEqualTo(discountCoupon.getCouponName());
+        assertThat(responseDto.getDiscount()).isEqualTo(discountCoupon.getDiscount());
     }
 
     @Test
     void 기존에_발급받은_쿠폰은_쿠폰_발급에_실패한다() {
 
-        Long couponId = 1L;
+        Long issuedCouponId = 2L;
 
-        given(principal.getUsername()).willReturn(email);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
-        given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(true);
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
+        given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), issuedCouponId)).willReturn(true);
 
-        ApiException exception = assertThrows(ApiException.class, () -> userCouponService.issueUserCoupon(storeId, couponId, principal));
+        ApiException exception = assertThrows(ApiException.class,
+            () -> userCouponService.issueUserCoupon(storeId, issuedCouponId, principal));
 
-        verify(userRepository).findByEmail(email);
-        verify(userCouponRepository).existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId);
         verify(storeRepository, never()).findByIdAndDeletedFalse(storeId);
-        verify(discountCouponRepository, never()).findIssuableCoupon(storeId, couponId);
+        verify(discountCouponRepository, never()).findIssuableCoupon(storeId, issuedCouponId);
         verify(userCouponRepository, never()).save(any(UserCoupon.class));
 
-        assertEquals(ErrorStatus.COUPON_ALREADY_ISSUED, exception.getErrorCode());
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.COUPON_ALREADY_ISSUED);
     }
 
     @Test
     void 발급받은_쿠폰_목록_조회에_성공한다() {
 
-        given(principal.getUsername()).willReturn(email);
-        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
         given(userCouponRepository.findAllByUser_idAndIsUsedFalse(user.getId())).willReturn(List.of(userCoupon));
 
         List<UserCouponIssueResponseDto> responseDtos = userCouponService.findMyUserCoupons(principal);
 
-        verify(userRepository).findByEmail(email);
-        verify(userCouponRepository).findAllByUser_idAndIsUsedFalse(user.getId());
-
-        assertEquals(responseDtos.size(), 1);
+        assertThat(responseDtos.size()).isEqualTo(1);
+        assertThat(responseDtos.get(0).getCouponName()).isEqualTo(userCoupon.getDiscountCoupon().getCouponName());
+        assertThat(responseDtos.get(0).getDiscount()).isEqualTo(userCoupon.getDiscountCoupon().getDiscount());
     }
 }

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceTest.java
@@ -1,7 +1,202 @@
 package com.example.springplusteamproject.domain.coupon.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.example.springplusteamproject.common.exception.ApiException;
+import com.example.springplusteamproject.common.status.ErrorStatus;
+import com.example.springplusteamproject.domain.coupon.dto.request.DiscountCouponRequestDto;
+import com.example.springplusteamproject.domain.coupon.dto.response.IssuableUserCouponResponseDto;
+import com.example.springplusteamproject.domain.coupon.dto.response.UserCouponIssueResponseDto;
+import com.example.springplusteamproject.domain.coupon.entity.DiscountCoupon;
+import com.example.springplusteamproject.domain.coupon.entity.UserCoupon;
+import com.example.springplusteamproject.domain.coupon.repository.DiscountCouponRepository;
+import com.example.springplusteamproject.domain.coupon.repository.UserCouponRepository;
+import com.example.springplusteamproject.domain.store.entity.Store;
+import com.example.springplusteamproject.domain.store.repository.StoreRepository;
+import com.example.springplusteamproject.domain.user.entity.User;
+import com.example.springplusteamproject.domain.user.repository.UserRepository;
+import com.example.springplusteamproject.security.CustomUserPrincipal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 class UserCouponServiceTest {
 
+    @Mock
+    private DiscountCouponRepository discountCouponRepository;
+
+    @Mock
+    private UserCouponRepository userCouponRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserCouponServiceImpl userCouponService;
+
+    private DiscountCouponRequestDto requestDto = new DiscountCouponRequestDto("5000원 할인", 5000L, LocalDate.now(),
+            LocalDate.now(), 100L);
+    private DiscountCoupon issuedDiscountCoupon;
+    private DiscountCoupon discountCoupon;
+    private CustomUserPrincipal principal;
+    private UserCoupon userCoupon;
+    private Long storeId;
+    private String email;
+    private Store store;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        issuedDiscountCoupon = DiscountCoupon.builder()
+                .id(2L)
+                .build();
+        discountCoupon = DiscountCoupon.builder()
+                .id(1L)
+                .couponName("쿠폰이름")
+                .stock(10L)
+                .build();
+        userCoupon = UserCoupon.builder()
+                .id(1L)
+                .discountCoupon(discountCoupon)
+                .build();
+
+        storeId = 1L;
+        principal = mock(CustomUserPrincipal.class);
+        user = mock(User.class);
+        store = mock(Store.class);
+        email = "test@gmail.com";
+    }
+
+    @Test
+    void 발급_가능한_쿠폰_목록_조회에_성공한다() {
+
+        given(principal.getUsername()).willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
+        given(userCouponRepository.findHavingCouponIds(user.getId(), storeId)).willReturn(List.of(2L));
+        given(discountCouponRepository.findIssuableCouponList(List.of(2L), storeId)).willReturn(
+                List.of(discountCoupon));
+
+        List<IssuableUserCouponResponseDto> responseDtos = userCouponService.findIssuableUserCoupons(storeId,
+                principal);
+        assertEquals(1, responseDtos.size());
+
+        verify(userRepository).findByEmail(email);
+        verify(storeRepository).findByIdAndDeletedFalse(storeId);
+        verify(userCouponRepository).findHavingCouponIds(user.getId(), storeId);
+        verify(discountCouponRepository).findIssuableCouponList(List.of(2L), storeId);
+    }
+
+    @Test
+    void 발급_가능한_쿠폰_상세_조회에_성공한다() {
+
+        Long couponId = 1L;
+
+        given(principal.getUsername()).willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(false);
+        given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
+        given(discountCouponRepository.findIssuableCoupon(storeId, couponId)).willReturn(Optional.of(discountCoupon));
+
+        IssuableUserCouponResponseDto responseDto = userCouponService.findIssuableUserCoupon(storeId, couponId,
+                principal);
+
+        verify(userRepository).findByEmail(email);
+        verify(userCouponRepository).existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId);
+        verify(storeRepository).findByIdAndDeletedFalse(storeId);
+        verify(discountCouponRepository).findIssuableCoupon(storeId, couponId);
+    }
+
+    @Test
+    void 이미_발급_받은_쿠폰은_상세_조회에_실패한다() {
+
+        Long couponId = 1L;
+
+        given(principal.getUsername()).willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(true);
+
+        ApiException exception = assertThrows(ApiException.class, () -> userCouponService.findIssuableUserCoupon(storeId, couponId, principal));
+
+        assertEquals(ErrorStatus.COUPON_ALREADY_ISSUED, exception.getErrorCode());
+
+        verify(userRepository).findByEmail(email);
+        verify(userCouponRepository).existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId);
+        verify(storeRepository, never()).findByIdAndDeletedFalse(storeId);
+        verify(discountCouponRepository, never()).findIssuableCoupon(storeId, couponId);
+    }
+
+    @Test
+    void 쿠폰_발급에_성공한다() {
+
+        Long couponId = 1L;
+
+        given(principal.getUsername()).willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(false);
+        given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
+        given(discountCouponRepository.findIssuableCoupon(storeId, couponId)).willReturn(Optional.of(discountCoupon));
+        given(userCouponRepository.save(any(UserCoupon.class))).willReturn(userCoupon);
+
+        userCouponService.issueUserCoupon(storeId, couponId, principal);
+
+        verify(userRepository).findByEmail(email);
+        verify(userCouponRepository).existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId);
+        verify(storeRepository).findByIdAndDeletedFalse(storeId);
+        verify(discountCouponRepository).findIssuableCoupon(storeId, couponId);
+        verify(userCouponRepository).save(any(UserCoupon.class));
+
+        assertEquals(discountCoupon.getStock(), 9L);
+    }
+
+    @Test
+    void 기존에_발급받은_쿠폰은_쿠폰_발급에_실패한다() {
+
+        Long couponId = 1L;
+
+        given(principal.getUsername()).willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(true);
+
+        ApiException exception = assertThrows(ApiException.class, () -> userCouponService.issueUserCoupon(storeId, couponId, principal));
+
+        verify(userRepository).findByEmail(email);
+        verify(userCouponRepository).existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId);
+        verify(storeRepository, never()).findByIdAndDeletedFalse(storeId);
+        verify(discountCouponRepository, never()).findIssuableCoupon(storeId, couponId);
+        verify(userCouponRepository, never()).save(any(UserCoupon.class));
+
+        assertEquals(ErrorStatus.COUPON_ALREADY_ISSUED, exception.getErrorCode());
+    }
+
+    @Test
+    void 발급받은_쿠폰_목록_조회에_성공한다() {
+
+        given(principal.getUsername()).willReturn(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(userCouponRepository.findAllByUser_idAndIsUsedFalse(user.getId())).willReturn(List.of(userCoupon));
+
+        List<UserCouponIssueResponseDto> responseDtos = userCouponService.findMyUserCoupons(principal);
+
+        verify(userRepository).findByEmail(email);
+        verify(userCouponRepository).findAllByUser_idAndIsUsedFalse(user.getId());
+
+        assertEquals(responseDtos.size(), 1);
+    }
 }

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceTest.java
@@ -1,0 +1,7 @@
+package com.example.springplusteamproject.domain.coupon.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserCouponServiceTest {
+
+}


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #22 

## ✨ 변경 사항
- `DiscountCouponRepository`의 메서드 명을 `findAvailableCoupon()` -> `findIssuableCoupon()`로 변경
- 쿠폰 등록 시 해당 가게 주인이 맞는지 검증 로직 추가
- validateOwner() 제거
- 쿠폰 등록 성공 / 실패 테스트 코드 추가
- 발급 가능한 쿠폰 목록 조회 성공 테스트 코드 추가
- 발급 가능한 쿠폰 상세 조회 성공 / 실패 테스트 코드 추가
- 쿠폰 발급 성공 / 실패 테스트 코드 추가
- 쿠폰 목록 조회 성공 테스트 코드 추가

## 📷 테스트 결과 
- UserCouponServiceTest 결과
<img width="526" alt="image" src="https://github.com/user-attachments/assets/d2e39641-e25f-4058-be37-4a07515a62d9" />

- DiscountCouponServiceTest 결과
<img width="515" alt="image" src="https://github.com/user-attachments/assets/11abced6-98e7-4162-a2ee-af8426201a97" />

- 전체 커버리지 결과
<img width="693" alt="image" src="https://github.com/user-attachments/assets/2c9a7004-8b47-4260-b5c5-976ab6a100b5" />

## ✅ 체크리스트
- [x] 관련 이슈에 연결됨
- [x] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
