### PR TITLE
Feat/대용량 처리 성능 확인 및 일부 누락 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.11'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/example/springplusteamproject/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/example/springplusteamproject/domain/store/service/StoreServiceImpl.java
@@ -45,6 +45,10 @@ public class StoreServiceImpl implements StoreService {
             throw new ApiException(ErrorStatus.STORE_BAD_REQUEST);
         }
 
+        if (ForbiddenWordUtil.containsForbiddenWord(dto.getName())) {
+            throw new ApiException(ErrorStatus.STORE_BAD_REQUEST);
+        }
+
         Store store = Store.builder()
             .name(dto.getName())
             .address(dto.getAddress())
@@ -96,14 +100,21 @@ public class StoreServiceImpl implements StoreService {
 
         String name = dto.getName();
 
-        if (storeRepository.existsByNameAndDeletedFalse(name)) {
-            return "이미 존재하는 상호명입니다.";
-        }
+        long start = System.nanoTime();
 
-        if (ForbiddenWordUtil.containsForbiddenWord(name)) {
-            return "부적절한 단어가 포함되어 있습니다.";
-        }
+        boolean exists = storeRepository.existsByNameAndDeletedFalse(name);
+        long afterExists = System.nanoTime();
 
+        boolean hasForbidden = ForbiddenWordUtil.containsForbiddenWord(name);
+        long afterForbidden = System.nanoTime();
+
+        System.out.printf("중복이름 조회: %.2fms, 금지어 확인: %.2fms%n",
+            (afterExists - start) / 1_000_000.0,
+            (afterForbidden - afterExists) / 1_000_000.0
+        );
+
+        if (exists) return "이미 존재하는 상호명입니다.";
+        if (hasForbidden) return "부적절한 단어가 포함되어 있습니다.";
         return "사용 가능한 상호명입니다.";
 
     }

--- a/src/test/java/com/example/springplusteamproject/store/performance/insert_100000_stores.sql
+++ b/src/test/java/com/example/springplusteamproject/store/performance/insert_100000_stores.sql
@@ -1,0 +1,23 @@
+INSERT INTO store (
+    store_name, deleted, address, image, min_order_price,
+    open_time, close_time, phone_number, user_id, created_at, modified_at
+)
+SELECT
+    CONCAT('store_', t.n),
+    false,
+    CONCAT('서울시 강남구_', t.n),
+    CONCAT('img_', t.n, '.jpg'),
+    10000 + t.n,
+    '09:00:00',
+    '18:00:00',
+    CONCAT('010-0000-', LPAD(t.n % 10000, 4, '0')),
+    1,
+    NOW(),
+    NOW()
+FROM (
+         SELECT @row := @row + 1 AS n
+         FROM information_schema.columns a,
+             information_schema.columns b,
+             (SELECT @row := 0) r
+             LIMIT 1000000
+     ) t;

--- a/src/test/java/com/example/springplusteamproject/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/store/service/StoreServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.springplusteamproject.store.service;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
 
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.PageRequest;
 
 import com.example.springplusteamproject.common.exception.ApiException;
+import com.example.springplusteamproject.common.request.CursorPageRequest;
 import com.example.springplusteamproject.common.response.CursorPageResponse;
 import com.example.springplusteamproject.domain.store.dto.request.StoreCheckNameRequestDto;
 import com.example.springplusteamproject.domain.store.dto.request.StoreRequestDto;
@@ -242,10 +244,22 @@ class StoreServiceTest {
         List<Store> mockResult = List.of(store1, store2);
         Pageable pageable = PageRequest.of(0, size);
 
-        CursorPageResponse<StoreListResponseDto> result = storeService.getStoresByCursor(cursor, size);
+        CursorPageRequest request = new CursorPageRequest(cursor, size);
+
+        given(storeRepository.findByCursor(cursor, pageable)).willReturn(mockResult);
+
+        // when
+        CursorPageResponse<StoreListResponseDto> result = storeService.getStoresByCursor(request);
 
         // then
+        assertThat(result.items()).hasSize(2);
+        assertThat(result.items().get(0).getName()).isEqualTo("장미 화원");
+        assertThat(result.items().get(1).getName()).isEqualTo("튤립 화원");
 
+        assertThat(result.pageInfo().nextCursor()).isEqualTo(98L);
+        assertThat(result.pageInfo().hasNext()).isFalse();
+
+        verify(storeRepository).findByCursor(cursor, pageable);
     }
 
     @Test


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #37 

## ✨ 변경 사항
- 대용량 데이터 처리 속도 확인
- 서비스 내의 가게 생성메서드에 금지어 사용여부 확인 로직 누락된것 추가

## 📷 Postman 
- ![image.png](attachment:ad691ddf-0cf1-4fc2-b5ed-5c32497befa7:image.png)
- ![image.png](attachment:34228fd0-ab49-4dad-8ee2-088020f555c9:image.png)
- ![image.png](attachment:de9d3d78-2009-4060-9d53-d23ef8a33269:image.png)

## ✅ 체크리스트
- [x] 관련 이슈에 연결됨
- [x] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
