### PR TITLE
[Feat] [Coupon] 쿠폰 수량 감소 분산락 적용

### DIFF
--- a/src/main/java/com/example/springplusteamproject/common/status/ErrorStatus.java
+++ b/src/main/java/com/example/springplusteamproject/common/status/ErrorStatus.java
@@ -143,7 +143,7 @@ public enum ErrorStatus implements BaseErrorCode {
     COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "C007", "해당 쿠폰이 없습니다."),
     COUPON_ALREADY_ISSUED(HttpStatus.CONFLICT, "C008", "이미 발급받은 쿠폰입니다."),
     COUPON_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "C004", "쿠폰의 수량이 소진되었습니다."),
-
+    COUPON_BAD_REQUEST(HttpStatus.BAD_REQUEST, "C004", "잘못된 요청입니다."),
 
 
 

--- a/src/main/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceImpl.java
+++ b/src/main/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceImpl.java
@@ -13,9 +13,12 @@ import com.example.springplusteamproject.domain.user.entity.User;
 import com.example.springplusteamproject.domain.user.repository.UserRepository;
 import com.example.springplusteamproject.security.CustomUserPrincipal;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,10 +28,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserCouponServiceImpl implements UserCouponService {
 
+    private final UserCouponTransactionalService userCouponTransactionalService;
     private final DiscountCouponRepository discountCouponRepository;
     private final UserCouponRepository userCouponRepository;
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
+    private final RedissonClient redissonClient;
 
     @Override
     @Transactional(readOnly = true)
@@ -69,20 +74,38 @@ public class UserCouponServiceImpl implements UserCouponService {
     }
 
     @Override
-    @Transactional
     public UserCouponIssueResponseDto issueUserCoupon(Long storeId, Long couponId, CustomUserPrincipal principal) {
 
         User user = validateActivateUser(principal.getUsername());
-        validateCouponNotIssued(user.getId(), couponId);
+        Long discountCouponId = discountCouponRepository.findById(couponId)
+            .orElseThrow(() -> new ApiException(ErrorStatus.COUPON_NOT_FOUND)).getId();
+        String lockKey = "coupon-lock:id: " + discountCouponId;
+        log.info("lockKey = {}", lockKey);
+        RLock lock = redissonClient.getLock(lockKey);
+        boolean isLocked;
 
-        validateActivateStore(storeId);
-        DiscountCoupon issuableCoupon = validateIssuableCoupon(storeId, couponId);
+        try {
+            isLocked = lock.tryLock(3000, 3000, TimeUnit.MILLISECONDS);
 
-        UserCoupon issueCoupon = createUserCoupon(user, issuableCoupon);
-        UserCoupon savedCoupon = userCouponRepository.save(issueCoupon);
-        issuableCoupon.decreaseStock();
+            if (!isLocked) {
+                log.warn("[Coupon - 쿠폰 발급] 락 획득 실패, couponId: {}", discountCouponId);
+                throw new ApiException(ErrorStatus.COUPON_BAD_REQUEST);
+            }
 
-        return UserCouponIssueResponseDto.from(issuableCoupon, savedCoupon);
+            return userCouponTransactionalService.issueUserCoupon(storeId, couponId, user);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("[Coupon - 쿠폰 발급] 락 인터럽트", e);
+            throw new ApiException(ErrorStatus.STORE_BAD_REQUEST);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                try {
+                    lock.unlock();
+                } catch (Exception e) {
+                    log.error("[Coupon - 쿠폰 발급] 락 해제 실패", e);
+                }
+            }
+        }
     }
 
     @Override
@@ -117,7 +140,8 @@ public class UserCouponServiceImpl implements UserCouponService {
 
     private void validateActivateStore(Long storeId) {
 
-        storeRepository.findByIdAndDeletedFalse(storeId).orElseThrow(() -> new ApiException(ErrorStatus.STORE_NOT_FOUND));
+        storeRepository.findByIdAndDeletedFalse(storeId)
+            .orElseThrow(() -> new ApiException(ErrorStatus.STORE_NOT_FOUND));
     }
 
     private void validateCouponNotIssued(Long userId, Long couponId) {

--- a/src/main/java/com/example/springplusteamproject/domain/coupon/service/UserCouponTransactionalService.java
+++ b/src/main/java/com/example/springplusteamproject/domain/coupon/service/UserCouponTransactionalService.java
@@ -1,0 +1,72 @@
+package com.example.springplusteamproject.domain.coupon.service;
+
+import com.example.springplusteamproject.common.exception.ApiException;
+import com.example.springplusteamproject.common.status.ErrorStatus;
+import com.example.springplusteamproject.domain.coupon.dto.response.UserCouponIssueResponseDto;
+import com.example.springplusteamproject.domain.coupon.entity.DiscountCoupon;
+import com.example.springplusteamproject.domain.coupon.entity.UserCoupon;
+import com.example.springplusteamproject.domain.coupon.repository.DiscountCouponRepository;
+import com.example.springplusteamproject.domain.coupon.repository.UserCouponRepository;
+import com.example.springplusteamproject.domain.store.repository.StoreRepository;
+import com.example.springplusteamproject.domain.user.entity.User;
+import com.example.springplusteamproject.domain.user.repository.UserRepository;
+import com.example.springplusteamproject.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserCouponTransactionalService {
+
+    private final StoreRepository storeRepository;
+
+    private final UserCouponRepository userCouponRepository;
+
+    private final DiscountCouponRepository discountCouponRepository;
+
+
+    @Transactional
+    public UserCouponIssueResponseDto issueUserCoupon(Long storeId, Long couponId, User user) {
+
+        validateCouponNotIssued(user.getId(), couponId);
+
+        validateActivateStore(storeId);
+        DiscountCoupon issuableCoupon = validateIssuableCoupon(storeId, couponId);
+
+        UserCoupon issueCoupon = createUserCoupon(user, issuableCoupon);
+        UserCoupon savedCoupon = userCouponRepository.save(issueCoupon);
+        issuableCoupon.decreaseStock();
+
+        return UserCouponIssueResponseDto.from(issuableCoupon, savedCoupon);
+    }
+
+    private void validateCouponNotIssued(Long userId, Long couponId) {
+
+        boolean alreadyIssued = userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(userId, couponId);
+        if (alreadyIssued) {
+            throw new ApiException(ErrorStatus.COUPON_ALREADY_ISSUED);
+        }
+    }
+
+    private void validateActivateStore(Long storeId) {
+
+        storeRepository.findByIdAndDeletedFalse(storeId).orElseThrow(() -> new ApiException(ErrorStatus.STORE_NOT_FOUND));
+    }
+
+    private DiscountCoupon validateIssuableCoupon(Long storeId, Long couponId) {
+
+        DiscountCoupon issuableCoupon = discountCouponRepository.findIssuableCoupon(storeId, couponId)
+            .orElseThrow(() -> new ApiException(ErrorStatus.COUPON_NOT_FOUND));
+
+        return issuableCoupon;
+    }
+
+    private UserCoupon createUserCoupon(User user, DiscountCoupon discountCoupon) {
+        return UserCoupon.builder()
+            .user(user)
+            .discountCoupon(discountCoupon)
+            .isUsed(false)
+            .build();
+    }
+}

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/CouponDistributedLockTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/CouponDistributedLockTest.java
@@ -1,0 +1,179 @@
+package com.example.springplusteamproject.domain.coupon.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.example.springplusteamproject.domain.coupon.entity.DiscountCoupon;
+import com.example.springplusteamproject.domain.coupon.repository.DiscountCouponRepository;
+import com.example.springplusteamproject.domain.coupon.repository.UserCouponRepository;
+import com.example.springplusteamproject.domain.store.entity.Store;
+import com.example.springplusteamproject.domain.store.repository.StoreRepository;
+import com.example.springplusteamproject.domain.user.entity.User;
+import com.example.springplusteamproject.domain.user.entity.UserRole;
+import com.example.springplusteamproject.domain.user.repository.UserRepository;
+import com.example.springplusteamproject.security.CustomUserPrincipal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class CouponDistributedLockTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private UserCouponRepository userCouponRepository;
+
+    @Autowired
+    private DiscountCouponRepository discountCouponRepository;
+
+    @Autowired
+    private UserCouponServiceImpl userCouponService;
+
+    private DiscountCoupon discountCoupon;
+    private CustomUserPrincipal principal;
+    private Store store;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        userCouponRepository.deleteAll();
+        discountCouponRepository.deleteAll();
+        storeRepository.deleteAll();
+        userRepository.deleteAll();
+        user = userRepository.save(User.builder()
+            .nickname("가게 주인")
+            .email("1@gmail.com")
+            .address("주소")
+            .password("1234")
+            .phone("01012345678")
+            .userRole(UserRole.OWNER)
+            .build());
+
+        store = storeRepository.save(Store.builder()
+            .name("가게 이름")
+            .user(user)
+            .closeTime(LocalTime.parse("21:00"))
+            .openTime(LocalTime.parse("08:00"))
+            .phoneNumber("0212345678")
+            .minOrderPrice(10000L)
+            .address("주소")
+            .deleted(false)
+            .build());
+
+        discountCoupon = discountCouponRepository.save(DiscountCoupon.builder()
+            .couponName("5000원 할인")
+            .discount(5000L)
+            .store(store)
+            .quantity(1000L)
+            .stock(1000L)
+            .issuedAt(LocalDate.now())
+            .expiresAt(LocalDate.now())
+            .build());
+    }
+
+    @Test
+    void 분산락을_이용한_할인_쿠폰_재고_동시성_처리_성공() throws InterruptedException {
+        int threadCount = 1000;
+        ExecutorService executor = Executors.newFixedThreadPool(100);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            int finalI = i;
+            executor.execute(() -> {
+                try {
+                    User user = userRepository.save(User.builder()
+                        .nickname("유저" + finalI)
+                        .email("user" + finalI + "@test.com")
+                        .password("1234")
+                        .phone("01012345678")
+                        .address("주소")
+                        .userRole(UserRole.CUSTOMER)
+                        .build());
+
+                    CustomUserPrincipal principal = new CustomUserPrincipal(user);
+
+                    userCouponService.issueUserCoupon(store.getId(), discountCoupon.getId(), principal);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        DiscountCoupon saved = discountCouponRepository.findById(discountCoupon.getId()).orElseThrow();
+        long issuedCount = userCouponRepository.count();
+
+        System.out.println("남은 재고: " + saved.getStock());
+        System.out.println("발급 수: " + issuedCount);
+
+        assertThat(saved.getStock()).isEqualTo(0);
+        assertThat(issuedCount).isEqualTo(1000);
+    }
+
+    @Test
+    void 재고_부족시_동시성_처리_성공() throws InterruptedException {
+        int threadCount = 1500;
+        ExecutorService executor = Executors.newFixedThreadPool(100);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            int finalI = i;
+            executor.execute(() -> {
+                try {
+                    User user = userRepository.save(User.builder()
+                        .nickname("유저" + finalI)
+                        .email("user" + finalI + "@test.com")
+                        .password("1234")
+                        .phone("01012345678")
+                        .address("주소")
+                        .userRole(UserRole.CUSTOMER)
+                        .build());
+
+                    CustomUserPrincipal principal = new CustomUserPrincipal(user);
+
+                    try {
+                        userCouponService.issueUserCoupon(store.getId(), discountCoupon.getId(), principal);
+                        successCount.getAndIncrement();
+                    } catch (Exception e) {
+                        failCount.getAndIncrement();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        DiscountCoupon saved = discountCouponRepository.findById(discountCoupon.getId()).orElseThrow();
+        long issuedCount = userCouponRepository.count();
+
+        System.out.println("남은 재고: " + saved.getStock());
+        System.out.println("발급 수: " + issuedCount);
+        System.out.println("성공 수: " + successCount.get());
+        System.out.println("실패 수: " + failCount.get());
+
+        assertThat(saved.getStock()).isEqualTo(0);
+        assertThat(issuedCount).isEqualTo(1000);
+        assertThat(successCount.get()).isEqualTo(1000);
+        assertThat(failCount.get()).isEqualTo(500);
+    }
+}

--- a/src/test/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceTest.java
+++ b/src/test/java/com/example/springplusteamproject/domain/coupon/service/UserCouponServiceTest.java
@@ -3,6 +3,8 @@ package com.example.springplusteamproject.domain.coupon.service;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,12 +25,15 @@ import com.example.springplusteamproject.domain.user.repository.UserRepository;
 import com.example.springplusteamproject.security.CustomUserPrincipal;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 
 @ExtendWith(MockitoExtension.class)
 class UserCouponServiceTest {
@@ -45,8 +50,14 @@ class UserCouponServiceTest {
     @Mock
     private UserRepository userRepository;
 
-    @InjectMocks
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RLock rLock;
+
     private UserCouponServiceImpl userCouponService;
+    private UserCouponTransactionalService userCouponTransactionalService;
 
     private DiscountCoupon issuedDiscountCoupon;
     private DiscountCoupon discountCoupon;
@@ -87,6 +98,16 @@ class UserCouponServiceTest {
             .user(user)
             .build();
         principal = new CustomUserPrincipal(user);
+        userCouponTransactionalService = new UserCouponTransactionalService(storeRepository, userCouponRepository, discountCouponRepository);
+
+        userCouponService = new UserCouponServiceImpl(
+            userCouponTransactionalService,
+            discountCouponRepository,
+            userCouponRepository,
+            storeRepository,
+            userRepository,
+            redissonClient
+        );
     }
 
     @Test
@@ -140,10 +161,12 @@ class UserCouponServiceTest {
     }
 
     @Test
-    void 쿠폰_발급에_성공한다() {
-
+    void 쿠폰_발급에_성공한다() throws InterruptedException {
         Long couponId = 1L;
 
+        given(redissonClient.getLock(anyString())).willReturn(rLock);
+        given(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).willReturn(true);
+        given(discountCouponRepository.findById(couponId)).willReturn(Optional.of(discountCoupon));
         given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
         given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), couponId)).willReturn(false);
         given(storeRepository.findByIdAndDeletedFalse(storeId)).willReturn(Optional.of(store));
@@ -158,11 +181,14 @@ class UserCouponServiceTest {
     }
 
     @Test
-    void 기존에_발급받은_쿠폰은_쿠폰_발급에_실패한다() {
+    void 기존에_발급받은_쿠폰은_쿠폰_발급에_실패한다() throws InterruptedException {
 
         Long issuedCouponId = 2L;
 
+        given(redissonClient.getLock(anyString())).willReturn(rLock);
+        given(rLock.tryLock(anyLong(), anyLong(), any(TimeUnit.class))).willReturn(true);
         given(userRepository.findByEmail(principal.getUsername())).willReturn(Optional.of(user));
+        given(discountCouponRepository.findById(issuedCouponId)).willReturn(Optional.of(issuedDiscountCoupon));
         given(userCouponRepository.existsByUser_IdAndDiscountCoupon_Id(user.getId(), issuedCouponId)).willReturn(true);
 
         ApiException exception = assertThrows(ApiException.class,


### PR DESCRIPTION
 ## 📌 관련 이슈
- Closes #57

## ✨ 변경 사항
- redisson을 이용하여 쿠폰 수량 감소시 동시성 제어
- UserCouponTransactionalService 추가
- 동시성 제어 테스트 코드 추가

## 📷 Postman 
- 이미지 첨부

## ✅ 체크리스트
- [x] 관련 이슈에 연결됨
- [x] 기능이 정상적으로 동작함
- [ ] 코드 리뷰를 받았음
- [ ] 불필요한 로그/코드 제거됨

## 💬 기타 참고 사항
- 테스트 방법, 추가 설명 등 필요한 경우 작성해 주세요.
